### PR TITLE
Make SSR for head use actual request url

### DIFF
--- a/Server/Index.fs
+++ b/Server/Index.fs
@@ -7,15 +7,9 @@ open Fable.Core
 open Fable.Core.JsInterop
 
 printfn "Importing createEndpoint"
-let createEndpoint : ReactElement -> unit = import "createEndpoint" "./server.js"
-
-printfn "Getting initState"
-let initState, _ = initByUrl ("/", Map.empty)
-
-printfn "generating headComponents"
-let headComponents = viewHead initState
+let createEndpoint : (string * string -> ReactElement) -> unit = import "createEndpoint" "./server.js"
 
 printfn "Creating endpoint"
-let endpoint = createEndpoint headComponents
+let endpoint = createEndpoint (initByUrl >> viewHead)
 
 

--- a/Server/server.js
+++ b/Server/server.js
@@ -3,13 +3,18 @@ import fs from 'fs';
 
 import ReactDOMServer from 'react-dom/server';
 import Helmet from 'react-helmet'
+import URL from 'url';
 
-function createEndpoint(headComponent) {  
+function createEndpoint(headComponentFun) {  
   const indexFile = path.resolve(__dirname, '../index.html');
   let indexContents = null;
   let didRead = false;
   return (req, res) => {
     console.log("Got a request!")
+    let reqUrl = URL.parse(req.url);
+    let pathName = reqUrl.pathname;
+    let queryString = reqUrl.search;
+    const headComponent = headComponentFun([pathName, queryString])
     ReactDOMServer.renderToString(headComponent);
     var helmet = Helmet.renderStatic();
     var headParts = `

--- a/src/App.fs
+++ b/src/App.fs
@@ -50,9 +50,9 @@ let vidSrc (dim:int) (fromValue, toValue) =
     sprintf "https://api.checkface.ml/api/mp4/?dim=%i&from_value=%s&to_value=%s" dim (encodeUriComponent fromValue) (encodeUriComponent toValue)
 
 let getCurrentPath _ =
-    let pathName = Browser.Dom.window.location.pathname
-    let queryString = Browser.Dom.window.location.search
+    Browser.Dom.window.location.pathname, Browser.Dom.window.location.search
 
+let parseSegments (pathName, queryString) =
     let urlSegments = Router.urlSegments pathName RouteMode.Path
     let urlParams =
         (Router.createUrlSearchParams queryString).entries()
@@ -60,8 +60,8 @@ let getCurrentPath _ =
         |> Map.ofSeq
     urlSegments, urlParams
 
-let initByUrl (path, query) = parseUrl (path, query), Cmd.none 
-let init() = getCurrentPath() |> initByUrl
+let initByUrl = parseSegments >> parseUrl
+let init() = getCurrentPath() |> initByUrl, Cmd.none
 
 let update msg state : State * Cmd<Msg> =
     match msg with
@@ -270,7 +270,7 @@ let viewHead state =
 let view state dispatch =
     React.router [
         router.pathMode
-        router.onUrlChanged (getCurrentPath >> UrlChanged >> dispatch)
+        router.onUrlChanged (getCurrentPath >> parseSegments >> UrlChanged >> dispatch)
         router.children [
             viewHead state
             render state dispatch

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -121,7 +121,7 @@ let client =
                 { from: resolve("vercel.json") },
             ]}),
             new CleanWebpackPlugin({
-                cleanOnceBeforeBuildPatterns: ['**/*', '!api'],
+                cleanOnceBeforeBuildPatterns: ['**/*', '!api/**'],
             }),
         ])
         : commonPlugins.concat([

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,6 +221,7 @@ let server =
         libraryTarget: "commonjs"
     },
     mode: isProduction ? 'production' : 'development',
+    devtool: isProduction ? 'source-map' : 'eval-source-map',
     // See https://github.com/fable-compiler/Fable/issues/1490
     resolve: {symlinks: false},
     plugins: [
@@ -285,8 +286,8 @@ let server =
         ]
     },
     optimization: {
-        minimize: true
-        // minimize: false
+        // minimize: true
+        minimize: false
     },
     node: {
         __dirname: false,


### PR DESCRIPTION
The head component was created using `/` and only once instead of being created based on the request url.