### PR TITLE
Add SliderMorph

### DIFF
--- a/src/App.fs
+++ b/src/App.fs
@@ -22,28 +22,26 @@ let siteName = "facemorph.me"
 let canonicalBaseUrl = "https://facemorph.me"
 
 type State = {
+    VidValues : (string * string) option
     LeftValue : string
     RightValue : string
-    VidValues : (string * string) option
     ShareOpen : bool
     ShareLinkMsg : string option
-    IsVideoLoading : bool
+    IsMorphLoading : bool
     UseSlider : bool
 }
 
+type UrlState = {
+    FromValue : string option
+    ToValue : string option
+}
+
 let parseUrl (path, query) =
-    let fromValue = Map.tryFind "from_value" query
-    let toValue = Map.tryFind "to_value" query
-    let vidValues = Option.map2 (fun a b -> a,b) fromValue toValue
     {
-        LeftValue = Option.defaultValue "hello" fromValue
-        RightValue = Option.defaultValue (System.DateTime.Today.ToString("yyyy-MM-dd")) toValue
-        VidValues = vidValues
-        ShareOpen = false
-        ShareLinkMsg = None
-        IsVideoLoading = vidValues.IsSome
-        UseSlider = false
+        FromValue = Map.tryFind "from_value" query
+        ToValue = Map.tryFind "to_value" query    
     }
+
 
 let canonicalUrl state =
     canonicalBaseUrl + Feliz.Router.Router.formatPath("/",
@@ -82,7 +80,7 @@ type Msg =
     | UrlChanged of (string list * Map<string, string>)
     | MakeVid
     | ShareMsg of ShareMsg
-    | VideoLoaded
+    | MorphLoaded
     | SetUseSlider of bool
 
 let imgSrc (dim:int) value =
@@ -107,7 +105,21 @@ let parseSegments (pathName, queryString) =
         |> Map.ofSeq
     urlSegments, urlParams
 
-let initByUrl = parseSegments >> parseUrl
+let defaultFromValue = Option.defaultValue "hello"
+let defaultToValue = Option.defaultWith (fun () -> System.DateTime.Today.ToString("yyyy-MM-dd"))
+
+let initByUrlstate urlState =
+    let vidValues = Option.map2 (fun a b -> a,b) urlState.FromValue urlState.ToValue
+    {
+        LeftValue = defaultFromValue urlState.FromValue
+        RightValue = defaultToValue urlState.ToValue
+        VidValues = vidValues
+        ShareOpen = false
+        ShareLinkMsg = None
+        IsMorphLoading = false
+        UseSlider = false
+    }
+let initByUrl = parseSegments >> parseUrl >> initByUrlstate
 let init() = getCurrentPath() |> initByUrl, Cmd.none
 
 let updateShare msg state =
@@ -180,11 +192,23 @@ let update msg state : State * Cmd<Msg> =
         gtagEvent "MakeVid" "Video"
         state, Cmd.navigatePath("/", ["from_value", state.LeftValue; "to_value", state.RightValue])
     | UrlChanged (path, query) ->
-        parseUrl (path, query), Cmd.none
+        let urlState = parseUrl (path, query)
+        let vidValues = Option.map2 (fun a b -> a,b) urlState.FromValue urlState.ToValue
+        //changed and has something to be loading
+        let isLoading = vidValues <> state.VidValues && vidValues.IsSome
+        {
+            state with
+                LeftValue = defaultFromValue urlState.FromValue
+                RightValue = defaultToValue urlState.ToValue
+                VidValues = vidValues
+                ShareOpen = false //always reset share state
+                ShareLinkMsg = None
+                IsMorphLoading = isLoading //set loading when has something to load
+        }, Cmd.none
     | ShareMsg msg ->
         updateShare msg state
-    | VideoLoaded ->
-        { state with IsVideoLoading = false }, Cmd.none
+    | MorphLoaded ->
+        { state with IsMorphLoading = false }, Cmd.none
     | SetUseSlider v ->
         { state with UseSlider = v }, Cmd.none
 
@@ -226,7 +250,7 @@ let renderMorph values useSlider dispatch =
             if useSlider then
                 sliderMorph {
                     Values = (fromValue, toValue)
-                    OnLoaded = (fun _ -> dispatch VideoLoaded)
+                    OnLoaded = (fun _ -> dispatch MorphLoaded)
                     FrameSrc = morphframeSrc
                     Dim = videoDim
                     NumFrames = 25
@@ -246,13 +270,14 @@ let renderMorph values useSlider dispatch =
                     prop.width videoDim
                     prop.height videoDim
                     prop.alt (sprintf "Morph from %s to %s" fromValue toValue)
-                    prop.onLoadedData (fun _ -> dispatch VideoLoaded)
+                    prop.onLoadedData (fun _ -> dispatch MorphLoaded)
                 ]
             Mui.formControlLabel [
                 prop.style [
                     style.display.block
                     style.margin.auto
                     style.maxWidth (length.px videoDim)
+                    style.height (length.px 0) //don't make morph button any lower
                 ]
                 formControlLabel.control (
                     Mui.checkbox [
@@ -295,7 +320,7 @@ let renderContent (state:State) (dispatch: Msg -> unit) =
                     prop.children [
                         renderSetpoint true state.LeftValue "Morph from" (SetLeftValue >> dispatch)
                         renderSetpoint false state.RightValue "Morph to" (SetRightValue >> dispatch)
-                        morphButton state.IsVideoLoading
+                        morphButton state.IsMorphLoading
                         renderMorph state.VidValues state.UseSlider dispatch
                     ]
                 ]

--- a/src/App.fsproj
+++ b/src/App.fsproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <Compile Include="Utils.fs" />
     <Compile Include="FancyButton.fs" />
+    <Compile Include="SliderMorph.fs" />
     <Compile Include="Explain.fs" />
     <Compile Include="App.fs" />
     <Compile Include="Index.fs" />

--- a/src/SliderMorph.fs
+++ b/src/SliderMorph.fs
@@ -1,0 +1,91 @@
+module SliderMorph
+
+open Feliz.MaterialUI
+open Feliz
+open Fable.Core.JsInterop
+open Fable.Core
+open Browser
+open Browser.Types
+open Fable.React.Helpers
+
+type [<AllowNullLiteral>] ImageType =
+    [<Emit("new Image($1...)")>] abstract Create: ?width: float * ?height: float -> HTMLImageElement
+
+let [<Global>] HTMLImageElement : ImageType = jsNative
+
+type Props = {
+    Values : string * string
+    OnLoaded : unit -> unit
+    FrameSrc : string * string -> int -> int -> int -> string
+    Dim : int
+    NumFrames : int
+}
+
+let sliderMorph = React.functionComponent ("canvas-face", fun (props : Props) ->
+        let canvasRef = React.useRef(None)
+        let frames = React.useRef(None)
+        let frameNum, setFrameNum = React.useState(props.NumFrames / 2) // using local state for frameNum for performance
+        printfn "Doing canvasface"
+        match frames.current with
+        | Some (frames:HTMLImageElement list,lastProps) when equalsButFunctions lastProps props ->
+            match canvasRef.current with
+            | None ->
+                console.log("Did nothing :(")
+                ()
+            | Some canvas ->
+                let canvas = unbox<HTMLCanvasElement> canvas
+                canvas.height <- float props.Dim
+                canvas.width <- float props.Dim
+                let context = canvas.getContext_2d ()
+                let currentFrame = min frameNum frames.Length // incase numframes decreases without moving slider
+                let currentImage = frames.[currentFrame - 1]
+                if currentImage.complete then
+                    context?drawImage(currentImage, 0., 0.)
+        | _ ->
+            console.log("Making image frames")
+            frames.current <-
+                let createImg n =
+                    let img = HTMLImageElement.Create (float props.Dim, float props.Dim)
+                    if n = frameNum then
+                        img.onload <- (ignore >> props.OnLoaded)
+                    img.src <- props.FrameSrc props.Values props.Dim props.NumFrames (n-1)
+                    img
+                let frames =
+                    [1..props.NumFrames]
+                    |> List.map createImg
+                Some (frames, props)
+                
+
+
+        Html.div [
+            prop.style [
+                // style.width dim
+                style.display.block
+                style.margin.auto
+            ]
+            prop.children [
+                Html.canvas [
+                    prop.ref canvasRef
+                    prop.style [
+                        style.maxWidth (length.percent 100)
+                        style.height length.auto
+                        style.display.block
+                        style.margin.auto
+                    ]
+                    prop.width props.Dim
+                    prop.height props.Dim
+                ]
+                Mui.slider [
+                    prop.style [
+                        style.display.block
+                        style.maxWidth (length.px props.Dim)
+                        style.margin.auto
+                    ]
+                    slider.min 1
+                    slider.max props.NumFrames
+                    slider.onChange setFrameNum
+                    slider.value frameNum
+                ]
+            ]
+        ]
+    )

--- a/src/SliderMorph.fs
+++ b/src/SliderMorph.fs
@@ -8,6 +8,7 @@ open Browser
 open Browser.Types
 open Fable.React.Helpers
 
+// workaround till proper fix for https://github.com/fable-compiler/fable-browser/issues/25
 type [<AllowNullLiteral>] ImageType =
     [<Emit("new Image($1...)")>] abstract Create: ?width: float * ?height: float -> HTMLImageElement
 
@@ -24,8 +25,8 @@ type Props = {
 let sliderMorph = React.functionComponent ("canvas-face", fun (props : Props) ->
         let canvasRef = React.useRef(None)
         let frames = React.useRef(None)
-        let frameNum, setFrameNum = React.useState(props.NumFrames / 2) // using local state for frameNum for performance
-        printfn "Doing canvasface"
+        let frameNum, setFrameNum = React.useState((* center *) 1 + props.NumFrames / 2) // using local state for frameNum for performance
+
         match frames.current with
         | Some (frames:HTMLImageElement list,lastProps) when equalsButFunctions lastProps props ->
             match canvasRef.current with
@@ -55,8 +56,6 @@ let sliderMorph = React.functionComponent ("canvas-face", fun (props : Props) ->
                     |> List.map createImg
                 Some (frames, props)
                 
-
-
         Html.div [
             prop.style [
                 // style.width dim


### PR DESCRIPTION
Some people have expressed wanting to control the position of the morph to see frame by frame.
This is currently possible by pausing the video and seeking, but depending on the browser and compression keyframes it isn't very adequate and can be quite slow.

This PR adds the option to use a slider to control the frame using canvas instead of video.