### PR TITLE
Add support for oembed

### DIFF
--- a/Server/Index.fs
+++ b/Server/Index.fs
@@ -9,6 +9,9 @@ open Fable.Core.JsInterop
 open System
 open Node
 open Bindings
+open FsToolkit.ErrorHandling
+open Checkface
+open Config
 
 let readIndexFile () =
     promise {
@@ -42,15 +45,11 @@ let titleRegex : obj = jsNative
 [<Emit("/<div id=\\\"elmish-app\\\"><\\/div>/")>]
 let elmishAppRegex : obj = jsNative
 
-let handleRequest (req: IncomingMessage) (res: VercelResponse) =
-    console.log ("Got a request!")
-    let reqUrl = URL.Create (req.url, $"http://%s{req.headers?host}")
-    let pathName = reqUrl.pathname
-    let queryString = reqUrl.search
-    let sheets = ServerStyleSheets()
+let serverSideRender (pathName, queryString) (res:VercelResponse) =
     let initState = initByUrl (pathName, queryString)
-    let dispatch = ignore
 
+    let dispatch = ignore
+    let sheets = ServerStyleSheets()
     let appComponent =
         viewWithoutRouter initState dispatch
         |> sheets.collect
@@ -72,10 +71,104 @@ let handleRequest (req: IncomingMessage) (res: VercelResponse) =
         match! indexContents.Value with
         | Some contents ->
             let body : string = contents?replace(titleRegex, headParts)?replace(elmishAppRegex, elmishApp)
+            let canonicalUrl = canonicalUrl initState
+            let oEmbedUrl = oEmbedUrl canonicalUrl
+            let title = pageTitle initState.VidValues
+            let oEmbedHeader = $"<%s{oEmbedUrl}>; rel=\"alternate\"; type=\"application/json+oembed\"; title=\"%s{title}\""
+            res.setHeader("Link", oEmbedHeader) |> ignore
             return res.status(200).send(body)
         | None ->
             console.log("Oops, no contents :(");
             return res.status(500).send("Oops, better luck next time!");
     }
+
+type ErrorCodes =
+    | NotImplemented
+    | BadRequest
+
+
+let oembed (pathName, queryString) (baseUrl:URL) (res:VercelResponse)=
+    let parseDimension dim =
+        match Int32.TryParse dim with
+        | true, v ->
+            if v >= 50 && v <= Config.maxSupportedImgDim then Ok v
+            else Error (BadRequest, "max dimension outside of acceptable range")
+        | false, _ -> Error (BadRequest, "max dimension not a number")
+
+    let (urlSegments, urlParams) = parseSegments (pathName, queryString)
+    let format = urlParams.TryFind "format" |> Option.defaultValue "json"
+
+
+    let response = result {
+        do! Result.requireEqual format "json" (NotImplemented, "format not implemented")
+        
+        let! maxwidth = urlParams.TryFind "maxwidth" |> Option.defaultValue (Config.ogImgDim.ToString()) |> parseDimension
+        let! maxheight = urlParams.TryFind "maxheight" |> Option.defaultValue (Config.ogImgDim.ToString()) |> parseDimension
+        let! embedUrl = urlParams.TryFind "url" |> Result.requireSome (BadRequest, "oembed url not specified")
+        let embedUrlParsed = URL.Create (embedUrl, baseUrl)
+        
+        // let isSameHost = embedUrlParsed.host = baseUrl.host
+        // if not isSameHost then
+        //     console.log("baseUrl", baseUrl)
+        //     return! Error (BadRequest, "oembed url requested is not serviced by this API endpoint. Check your oembed configuration")
+        
+
+        let initState = initByUrl (embedUrlParsed.pathname, embedUrlParsed.search)
+        let dim = Math.Min(maxwidth, maxheight)
+        let thumbDim = Math.Min(dim, thumbnailDim)
+        let (imgUrl, thumbnailUrl, title) =
+            match initState.VidValues with
+            | Some (fromValue, toValue) ->
+                animatedWebpSrc dim (fromValue, toValue),
+                imgSrc dim false fromValue,
+                sprintf "%s to %s" (shortCheckfaceSrcDesc fromValue) (shortCheckfaceSrcDesc toValue)
+                
+            | None ->
+                imgSrc dim true initState.LeftValue,
+                imgSrc thumbDim false initState.LeftValue,
+                shortCheckfaceSrcDesc initState.LeftValue
+
+        let data = createObj [
+            "version" ==> "1.0"
+            "type" ==> "photo"
+            "width" ==> dim
+            "height" ==> dim
+            "title" ==> title
+            "url" ==> imgUrl
+            "thumbnail_url" ==> thumbnailUrl
+            "thumbnail_width" ==> thumbDim
+            "thumbnail_height" ==> thumbDim
+            "provider_name" ==> siteName
+            "provider_url" ==> canonicalBaseUrl
+        ]
+        return data
+    }
+
+    promise {
+        match response with
+        | Ok data ->
+            return res.status(200).json(data)
+        | Error (statusCode, message) ->
+            let status =
+                match statusCode with
+                | BadRequest -> 400
+                | NotImplemented -> 501
+            return res.status(status).send(message)
+    }
+
+let handleRequest (req: IncomingMessage) (res: VercelResponse) =
+    console.log ("Got a request!")
+    let baseUrl = URL.Create $"http://%s{req.headers?host}"
+    let reqUrl = URL.Create (req.url, baseUrl)
+    let pathName = reqUrl.pathname
+    let queryString = reqUrl.search
+    match pathName with
+    | "/oembed.json"
+    | "/oembed.json/" ->
+        oembed (pathName, queryString) baseUrl res
+    | _ ->
+        serverSideRender (pathName, queryString) res
+
+
 
 exportDefault handleRequest

--- a/Server/Node.fs
+++ b/Server/Node.fs
@@ -51,6 +51,8 @@ type VercelResponse =
     abstract send : body: string -> VercelResponse
     abstract send : body: Buffer -> VercelResponse
     // abstract send : body: obj -> VercelResponse
+    abstract json : body: obj -> VercelResponse
+    abstract setHeader : name : string * value : string -> VercelResponse
 
 
 [<Global>]

--- a/Server/Server.fsproj
+++ b/Server/Server.fsproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Elmish.React" Version="3.0.1" />
+    <PackageReference Include="FsToolkit.ErrorHandling" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/App.fs
+++ b/src/App.fs
@@ -55,6 +55,9 @@ let formatPathForVidValues vidValues =
 let canonicalUrl state =
     canonicalBaseUrl + formatPathForVidValues state.VidValues
 
+let oEmbedUrl (url:string) =
+    oEmbedApiEndpoint + (Feliz.Router.Router.formatPath("", [ "url", url ]))
+
 let pageTitle vidValues =
     match vidValues with
     | Some (fromValue, toValue) ->
@@ -348,21 +351,29 @@ let meta (property:string) content =
 
 let viewHead state =
     let canonicalUrl = canonicalUrl state
+    let title = pageTitle state.VidValues
 
     helmet [ 
         prop.children [
-            Html.title (str (pageTitle state.VidValues))
+            Html.title (str title)
             Html.meta [
                 prop.custom ("property", "description")
                 prop.custom ("name", "description")
                 prop.custom ("content", pageDescription None)
             ]
-            meta "og:title" (pageTitle state.VidValues)
+            meta "og:title" (title)
             meta "og:description" (pageDescription None)
             meta "og:site_name" siteName
 
             Html.link [ prop.rel.canonical; prop.href canonicalUrl ]
             meta "og:url" canonicalUrl
+
+            Html.link [
+                rel.alternate
+                prop.custom ("type", "application/json+oembed")
+                prop.href (oEmbedUrl canonicalUrl)
+                prop.title $"oEmbed for %s{title}"
+            ]
 
             match state.VidValues with
             | None -> // just use left value if no video

--- a/src/Checkface.fs
+++ b/src/Checkface.fs
@@ -45,6 +45,9 @@ let imgSrc (dim:int) isWebp value =
 let vidSrc (dim:int) (fromValue, toValue) =
     sprintf "%s/api/mp4/?dim=%i&from_%s&to_%s" apiAddr dim (valueParam fromValue) (valueParam toValue)
 
+let animatedWebpSrc (dim:int) (fromValue, toValue) =
+    sprintf "%s/api/webp/?dim=%i&from_%s&to_%s" apiAddr dim (valueParam fromValue) (valueParam toValue)
+
 let morphframeSrc (fromValue, toValue) dim numFrames frameNum =
     sprintf "%s/api/morphframe/?dim=%i&linear=true&from_%s&to_%s&num_frames=%i&frame_num=%i" apiAddr dim (valueParam fromValue) (valueParam toValue) numFrames frameNum
 

--- a/src/Config.fs
+++ b/src/Config.fs
@@ -7,9 +7,13 @@ let linkpreviewWidth = 1200
 let linkpreviewHeight = 628
 let ogImgDim = 512
 let ogVideoDim = 512
+let maxSupportedImgDim = 1024
+let thumbnailDim = 128
 
 let siteName = "facemorph.me"
 let canonicalBaseUrl = "https://facemorph.me"
+// let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
+let oEmbedApiEndpoint = "https://oembed.vercel.facemorph.me/"  + "/oembed.json"
 let contactEmail = "checkfaceml@gmail.com"
 let githubRepo = "check-face/facemorph.me"
 

--- a/src/Config.fs
+++ b/src/Config.fs
@@ -12,8 +12,7 @@ let thumbnailDim = 128
 
 let siteName = "facemorph.me"
 let canonicalBaseUrl = "https://facemorph.me"
-// let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
-let oEmbedApiEndpoint = "https://oembed.vercel.facemorph.me/"  + "/oembed.json"
+let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
 let contactEmail = "checkfaceml@gmail.com"
 let githubRepo = "check-face/facemorph.me"
 


### PR DESCRIPTION
Starting with just `photo`, and using the animated webp. Hopefully consumers are happy to show an animated webp.

In the future it would be nice to make it interactive with `video` or `html` type and include option to use slider. And of course include logo with link to main site.