### PR TITLE
Make vercel cache html page renders, at least for index

### DIFF
--- a/Server/Index.fs
+++ b/Server/Index.fs
@@ -71,7 +71,7 @@ let serverSideRender (pathName, queryString) (res:VercelResponse) =
         match! indexContents.Value with
         | Some contents ->
             let body : string = contents?replace(titleRegex, headParts)?replace(elmishAppRegex, elmishApp)
-            let cacheControlHeader = "public, max-age=3600, s-max-age=3600, stale-while-revalidate=172800, immutable"
+            let cacheControlHeader = "public, max-age=3600, s-max-age=3600, stale-while-revalidate=172800"
             return res.status(200).setHeader("Cache-Control", cacheControlHeader).send(body)
         | None ->
             console.log("Oops, no contents :(");

--- a/Server/Index.fs
+++ b/Server/Index.fs
@@ -71,7 +71,7 @@ let serverSideRender (pathName, queryString) (res:VercelResponse) =
         match! indexContents.Value with
         | Some contents ->
             let body : string = contents?replace(titleRegex, headParts)?replace(elmishAppRegex, elmishApp)
-            let cacheControlHeader = "max-age=3600, s-max-age=3600, stale-while-revalidate=172800"
+            let cacheControlHeader = "public, max-age=3600, s-max-age=3600, stale-while-revalidate=172800, immutable"
             return res.status(200).setHeader("Cache-Control", cacheControlHeader).send(body)
         | None ->
             console.log("Oops, no contents :(");

--- a/Server/Index.fs
+++ b/Server/Index.fs
@@ -71,7 +71,8 @@ let serverSideRender (pathName, queryString) (res:VercelResponse) =
         match! indexContents.Value with
         | Some contents ->
             let body : string = contents?replace(titleRegex, headParts)?replace(elmishAppRegex, elmishApp)
-            return res.status(200).send(body)
+            let cacheControlHeader = "max-age=3600, s-max-age=3600, stale-while-revalidate=172800"
+            return res.status(200).setHeader("Cache-Control", cacheControlHeader).send(body)
         | None ->
             console.log("Oops, no contents :(");
             return res.status(500).send("Oops, better luck next time!");
@@ -96,17 +97,17 @@ let oembed (pathName, queryString) (baseUrl:URL) (res:VercelResponse)=
 
     let response = result {
         do! Result.requireEqual format "json" (NotImplemented, "format not implemented")
-        
+
         let! maxwidth = urlParams.TryFind "maxwidth" |> Option.defaultValue (Config.ogImgDim.ToString()) |> parseDimension
         let! maxheight = urlParams.TryFind "maxheight" |> Option.defaultValue (Config.ogImgDim.ToString()) |> parseDimension
         let! embedUrl = urlParams.TryFind "url" |> Result.requireSome (BadRequest, "oembed url not specified")
         let embedUrlParsed = URL.Create (embedUrl, baseUrl)
-        
+
         // let isSameHost = embedUrlParsed.host = baseUrl.host
         // if not isSameHost then
         //     console.log("baseUrl", baseUrl)
         //     return! Error (BadRequest, "oembed url requested is not serviced by this API endpoint. Check your oembed configuration")
-        
+
 
         let initState = initByUrl (embedUrlParsed.pathname, embedUrlParsed.search)
         let dim = Math.Min(maxwidth, maxheight)
@@ -117,7 +118,7 @@ let oembed (pathName, queryString) (baseUrl:URL) (res:VercelResponse)=
                 animatedWebpSrc dim (fromValue, toValue),
                 imgSrc dim false fromValue,
                 sprintf "%s to %s" (shortCheckfaceSrcDesc fromValue) (shortCheckfaceSrcDesc toValue)
-                
+
             | None ->
                 imgSrc dim true initState.LeftValue,
                 imgSrc thumbDim false initState.LeftValue,

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
     "enabled": false
   },
   "routes": [
-    { "src": "/.*", "continue": true, "headers": { "cache-control": "max-age=3600, s-maxage=86400" } },
+    { "src": "/.*", "continue": true, "headers": { "Cache-Control": "max-age=3600, s-maxage=86400" } },
     { "src": "/index.html", "dest": "/api/server" },
     { "src": "/", "dest": "/api/server" },
     { "handle": "filesystem" },


### PR DESCRIPTION
It looks like vercel isn't caching SSR even for the main index page. This is an attempt to fix that.

0679d69e8e4b2831572ab6fd327a197dcb403ff0 was the first attempt but it seemed to break the vercel lambda. Not sure why, so need to test in vercel staging