### PR TITLE
Add facemorph retirement notice

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,7 @@ jobs:
           curl -fsSL "https://nodejs.org/dist/v20.19.5/node-v20.19.5-linux-${node_arch}.tar.xz" -o /tmp/node.tar.xz
           mkdir -p /opt/node20
           tar -xJf /tmp/node.tar.xz --strip-components=1 -C /opt/node20
+          export PATH="/opt/node20/bin:$PATH"
           echo "/opt/node20/bin" >> "$GITHUB_PATH"
           node -v
           npm -v

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,10 @@
 
 name: CI
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 on:
   push:
     branches: [ master ]
@@ -8,39 +12,64 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:5.0-focal
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '12'
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '5.0.x'
-          global-json-file: global.json
-      - run: npm install
-      - run: npm run build
-
-      # https://github.com/amondnet/vercel-action/blob/f79b066724a2ac14b8944244a625146e5d6006c3/.github/workflows/example-static.yml
-      - name: production or not
-        id: prod_or_not
+      - name: Install Node 20
         run: |
-          if [ "$REF" == 'refs/heads/master' ]
-          then
-              echo "vercel-args=--prod" >> "$GITHUB_OUTPUT"
-          else
-              echo "vercel-args=" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          REF: ${{ github.ref }}
-
-      - uses: amondnet/vercel-action@v19
-        with:
-          # github-token: ${{ secrets.GITHUB_TOKEN }}
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          alias-domains: |
-            {{BRANCH}}.vercel.facemorph.me
-          vercel-args: ${{ steps.prod_or_not.outputs.vercel-args }}
+          set -euo pipefail
+          apt-get update
+          apt-get install -y curl ca-certificates xz-utils
+          arch="$(uname -m)"
+          case "$arch" in
+            x86_64|amd64) node_arch=x64 ;;
+            aarch64|arm64) node_arch=arm64 ;;
+            *)
+              echo "Unsupported architecture: $arch" >&2
+              exit 1
+              ;;
+          esac
+          curl -fsSL "https://nodejs.org/dist/v20.19.5/node-v20.19.5-linux-${node_arch}.tar.xz" -o /tmp/node.tar.xz
+          mkdir -p /opt/node20
+          tar -xJf /tmp/node.tar.xz --strip-components=1 -C /opt/node20
+          echo "/opt/node20/bin" >> "$GITHUB_PATH"
+          node -v
+          npm -v
+          dotnet --version
+      - name: Install dependencies
+        run: npm install
+      - name: Build site
+        run: npm run build
+      - name: Link deploy output to the Vercel project
+        run: |
+          set -euo pipefail
+          mkdir -p deploy/.vercel
+          cat > deploy/.vercel/project.json <<EOF
+          {
+            "orgId": "${VERCEL_ORG_ID}",
+            "projectId": "${VERCEL_PROJECT_ID}"
+          }
+          EOF
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
+        id: deploy_preview
+        run: |
+          set -euo pipefail
+          url="$(vercel --cwd deploy --token="${{ secrets.VERCEL_TOKEN }}" --archive=tgz --yes)"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Deploy production
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        id: deploy_production
+        run: |
+          set -euo pipefail
+          url="$(vercel --cwd deploy --prod --token="${{ secrets.VERCEL_TOKEN }}" --archive=tgz --yes)"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Summarize preview deployment
+        if: steps.deploy_preview.outputs.url != ''
+        run: echo "Preview deployment: ${{ steps.deploy_preview.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Summarize production deployment
+        if: steps.deploy_production.outputs.url != ''
+        run: echo "Production deployment: ${{ steps.deploy_production.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '5.0.x'
+          global-json-file: global.json
       - run: npm install
       - run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/dotnet/sdk:5.0-focal
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Node 20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '12'
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '5.0.x'
       - run: npm install
       - run: npm run build
 
@@ -23,9 +26,9 @@ jobs:
         run: |
           if [ "$REF" == 'refs/heads/master' ]
           then
-              echo "::set-output name=vercel-args::--prod"
+              echo "vercel-args=--prod" >> "$GITHUB_OUTPUT"
           else
-              echo "::set-output name=vercel-args::"
+              echo "vercel-args=" >> "$GITHUB_OUTPUT"
           fi
         env:
           REF: ${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,9 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Summarize preview deployment
         if: steps.deploy_preview.outputs.url != ''
-        run: echo "Preview deployment: ${{ steps.deploy_preview.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          echo "Preview deployment: ${{ steps.deploy_preview.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
       - name: Summarize production deployment
         if: steps.deploy_production.outputs.url != ''
-        run: echo "Production deployment: ${{ steps.deploy_production.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          echo "Production deployment: ${{ steps.deploy_production.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,11 @@ jobs:
         run: npm install
       - name: Build site
         run: npm run build
-      - name: Link deploy output to the Vercel project
+      - name: Link the repository to the Vercel project
         run: |
           set -euo pipefail
-          mkdir -p deploy/.vercel
-          cat > deploy/.vercel/project.json <<EOF
+          mkdir -p .vercel
+          cat > .vercel/project.json <<EOF
           {
             "orgId": "${VERCEL_ORG_ID}",
             "projectId": "${VERCEL_PROJECT_ID}"
@@ -62,14 +62,14 @@ jobs:
         id: deploy_preview
         run: |
           set -euo pipefail
-          url="$(vercel --cwd deploy --token="${{ secrets.VERCEL_TOKEN }}" --archive=tgz --yes)"
+          url="$(vercel --token="${{ secrets.VERCEL_TOKEN }}" --archive=tgz --yes)"
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Deploy production
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         id: deploy_production
         run: |
           set -euo pipefail
-          url="$(vercel --cwd deploy --prod --token="${{ secrets.VERCEL_TOKEN }}" --archive=tgz --yes)"
+          url="$(vercel --prod --token="${{ secrets.VERCEL_TOKEN }}" --archive=tgz --yes)"
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Summarize preview deployment
         if: steps.deploy_preview.outputs.url != ''

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.302",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/App.fs
+++ b/src/App.fs
@@ -302,6 +302,50 @@ let footer =
         ]
     ]
 
+let retirementNotice =
+    Html.aside [
+        prop.className "retirement-notice"
+        prop.children [
+            Mui.container [
+                container.maxWidth.md
+                container.children [
+                    Html.div [
+                        prop.className "retirement-notice__content"
+                        prop.children [
+                            Html.div [
+                                prop.className "retirement-notice__copy"
+                                prop.children [
+                                    Html.p [
+                                        Html.strong "Transition notice."
+                                        str $" We expect facemorph.me to retire by %s{retirementDeadlineLabel}."
+                                    ]
+                                    Html.p [
+                                        str "We are working on a lower-cost preservation path so historic checkfaces can keep working in some form after the current server is retired."
+                                    ]
+                                ]
+                            ]
+                            Html.div [
+                                prop.className "retirement-notice__actions"
+                                prop.children [
+                                    Mui.link [
+                                        link.color.initial
+                                        prop.href (sprintf "mailto:%s" contactEmail)
+                                        prop.text "Send feedback"
+                                    ]
+                                    Mui.link [
+                                        link.color.initial
+                                        prop.href (sprintf "https://github.com/%s/issues" githubRepo)
+                                        prop.text "Request a workflow"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+
 let createTheme isDark = [
     if isDark then theme.palette.type'.dark else theme.palette.type'.light
     theme.palette.background.default' <| if isDark then "#17181c" else "white"
@@ -342,6 +386,7 @@ let render (state:State) (dispatch: Msg -> unit) =
         viewShareContent (getShareState state) (ShareMsg >> dispatch)
         Explain.view ()
         footer
+        retirementNotice
     ]
 
 let inline helmet props = createElement (Fable.Core.JsInterop.import "Helmet" "react-helmet") props

--- a/src/App.fs
+++ b/src/App.fs
@@ -329,13 +329,13 @@ let retirementNotice =
                                 prop.children [
                                     Mui.link [
                                         link.color.initial
-                                        prop.href (sprintf "mailto:%s" contactEmail)
-                                        prop.text "Send feedback"
+                                        prop.href "#learn-more-transition"
+                                        prop.text "Learn More"
                                     ]
                                     Mui.link [
                                         link.color.initial
-                                        prop.href (sprintf "https://github.com/%s/issues" githubRepo)
-                                        prop.text "Request a workflow"
+                                        prop.href (sprintf "mailto:%s" contactEmail)
+                                        prop.text "Contact us"
                                     ]
                                 ]
                             ]

--- a/src/App.fs
+++ b/src/App.fs
@@ -316,11 +316,11 @@ let retirementNotice =
                                 prop.className "retirement-notice__copy"
                                 prop.children [
                                     Html.p [
-                                        Html.strong "Transition notice."
+                                        Html.strong "Planning notice."
                                         str $" We expect facemorph.me to retire by %s{retirementDeadlineLabel}."
                                     ]
                                     Html.p [
-                                        str "We are working on a lower-cost preservation path so historic checkfaces can keep working in some form after the current server is retired."
+                                        str "We are documenting the preservation path first so historic checkfaces can keep working in some form after the current Triton-backed service is retired."
                                     ]
                                 ]
                             ]
@@ -331,11 +331,6 @@ let retirementNotice =
                                         link.color.initial
                                         prop.href "#learn-more-transition"
                                         prop.text "Learn More"
-                                    ]
-                                    Mui.link [
-                                        link.color.initial
-                                        prop.href (sprintf "mailto:%s" contactEmail)
-                                        prop.text "Contact us"
                                     ]
                                 ]
                             ]

--- a/src/Config.fs
+++ b/src/Config.fs
@@ -15,6 +15,7 @@ let canonicalBaseUrl = "https://facemorph.me"
 let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
 let contactEmail = "checkfaceml@gmail.com"
 let githubRepo = "check-face/facemorph.me"
+let retirementDeadlineLabel = "June 20, 2026 (AEST)"
 
 let defaultTextValue = "hello"
 let defaultNumericSeed = 389u // 389 is one of the seeds featured in the stylegan2 paper

--- a/src/explain.md
+++ b/src/explain.md
@@ -27,29 +27,101 @@ image but should work well for morphing.
 
 ## Retirement and transition
 
-facemorph.me is now in transition mode and the current goal is to retire the existing service by **June 20, 2026 (AEST)**.
+facemorph.me is now in retirement planning mode and the current goal is to retire the existing always-on service by **June 20, 2026 (AEST)**.
+
+The point of this page is to explain the process before anything major changes.
+The current site is still online while we document the service, audit historic hashes and cached outputs, and test lower-cost ways to keep the important parts alive after the current Triton-backed deployment is retired.
+
+### Why this is happening
 
 The present deployment depends on an aging GPU and container stack that is getting harder and more expensive to keep online.
-Our priority is to preserve historic checkfaces and move the service toward a lower-cost setup, likely with more of the live generation path shifted onto Hugging Face.
+That stack has been useful for a long time, but it is no longer a good forever-home for a public always-on service.
 
-That means the post-transition service may not look exactly like today's stack.
-Some workflows may move to slower on-demand generation, authenticated Hugging Face usage, archived outputs, or self-hosted/local options.
+We want to avoid a bad outcome where the old stack simply becomes too expensive or brittle and then disappears without warning.
+The goal here is to document the service properly, preserve what matters most, and move users onto a lower-cost path in a more deliberate way.
 
-If there is a workflow you need us to preserve, please contact us using the email address in the footer.
+### What we are trying to preserve
+
+- historic checkfaces that users already rely on
+- the ability to match historic hashes where we can verify exact preservation
+- a usable replacement path for people who still want to generate faces after the current machine is retired
+- enough documentation that people can understand what changed and, if necessary, run their own copy locally in future
+
+### What is happening now
+
+Right now we are still in the planning and documentation stage.
+That means:
+
+- the current site stays up while we investigate
+- we are inventorying old cached outputs and historic hash behavior
+- we are working out which results can be preserved exactly and which may need a slower replacement path
+- we expect to use `testing.facemorph.me` as the place for candidate replacements before changing the main site
+- we are looking at Hugging Face as the most likely low-cost home for at least part of the future service
+
+### What may change later
+
+We expect the post-transition service to be more explicit about tradeoffs than the current setup.
+Depending on what we prove during the investigation, that may mean:
+
+- slower on-demand generation instead of a permanently warm GPU service
+- sign-in via Hugging Face for some compute-heavy workflows
+- archived historic outputs being served directly, rather than regenerated every time
+- a replacement API surface that is similar to today's API, or a documented move onto Hugging Face-native equivalents
+- some older or more expensive flows being documented for self-hosting rather than kept online as a public free service
+
+### The planned process
+
+1. Document the current Triton deployment, data layout, and existing public behavior.
+2. Audit the historic hashes, cached outputs, and model/version boundaries so we know what "preservation" really means.
+3. Prototype lower-cost replacements, most likely using Hugging Face for authentication and at least some generation or archive-serving duties.
+4. Publish test builds and placeholder flows on `testing.facemorph.me` so users can try them before production changes.
+5. Publish final retirement details only after we understand what can be preserved exactly, what will be slower, and what will need to change.
+6. Retire the old always-on service once the replacement path and archive story are documented well enough to stand on their own.
+
+### What is not promised yet
+
+We do **not** want to overstate what is solved.
+At this stage we are still validating the details, so we are **not** yet promising:
+
+- exact parity for every uncached request
+- the same performance profile as the current server
+- indefinite uptime for the current API
+- that every current workflow will survive unchanged
+
+### API users
+
+The current API will eventually need to be retired along with the current machine.
+Before that happens, we intend to document the likely replacement path clearly.
+
+The most likely direction is that the API stops being a public always-on service on our own GPU box and becomes one of:
+
+- a Hugging Face-backed replacement
+- a thinner compatibility layer in front of a Hugging Face workflow
+- a more limited preservation endpoint for historic content, with newer generation handled separately
+
+That work is still being scoped.
+If you depend on the API, the main thing to expect right now is more documentation, a testing surface, and advance notice before the old endpoint is shut down.
+
+### Before you contact us
+
+Please read this page first.
+If you still have a workflow that you need preserved after reading it, email the address in the footer and explain the exact path you rely on.
+
+For transition questions and preservation feedback, please use email rather than GitHub issues.
 
 ## FAQ
 
----
-
 #### Is facemorph.me being retired?
-Yes. The current target is to retire the existing service by **June 20, 2026 (AEST)**.
+Yes.
+The current goal is to retire the existing always-on service by **June 20, 2026 (AEST)**, but this page exists specifically so the process is documented before that happens.
 
-The current stack depends on older GPU/container build assumptions that are getting harder and more expensive to keep alive.
-We are investigating a lower-cost preservation path focused on keeping historic checkfaces available in some form, likely with more of the load shifted onto Hugging Face.
+#### Is anything changing today?
+Not yet in a major way.
+The current site is still online while we document the existing service, investigate historic hash preservation, and prepare a testing surface for whatever comes next.
 
-If you have a workflow you want preserved, please email the address in the footer so we can factor it into the transition.
-
----
+#### What should API users expect?
+The current Triton-hosted API is not intended to remain the long-term public service.
+Before that changes, we intend to document the replacement direction clearly, publish a testing surface, and give advance notice rather than simply switching it off.
 
 #### Are these real people?
 Images based on text input or numeric seeds are not really people. They are randomly generated.
@@ -118,5 +190,5 @@ The source code for our server is at [github.com/check-face/checkface](https://g
 It is documented at [checkface.facemorph.me/api](https://checkface.facemorph.me/api)
 <!-- or at https://github.com/check-face/checkface/blob/master/docs/api.md -->
 
-We recommented hosting the server yourself as we do not plan on running it reliably or indefinitely.
+We recommended hosting the server yourself as we do not plan on running it reliably or indefinitely.
 Feel free to contact us using the email address in the footer.

--- a/src/explain.md
+++ b/src/explain.md
@@ -23,6 +23,20 @@ It attempts to find a balance between accuracy and editability.
 This tradeoff means it won't look quite the same as the input
 image but should work well for morphing.
 
+<div id="learn-more-transition"></div>
+
+## Retirement and transition
+
+facemorph.me is now in transition mode and the current goal is to retire the existing service by **June 20, 2026 (AEST)**.
+
+The present deployment depends on an aging GPU and container stack that is getting harder and more expensive to keep online.
+Our priority is to preserve historic checkfaces and move the service toward a lower-cost setup, likely with more of the live generation path shifted onto Hugging Face.
+
+That means the post-transition service may not look exactly like today's stack.
+Some workflows may move to slower on-demand generation, authenticated Hugging Face usage, archived outputs, or self-hosted/local options.
+
+If there is a workflow you need us to preserve, please contact us using the email address in the footer.
+
 ## FAQ
 
 ---

--- a/src/explain.md
+++ b/src/explain.md
@@ -27,6 +27,16 @@ image but should work well for morphing.
 
 ---
 
+#### Is facemorph.me being retired?
+Yes. The current target is to retire the existing service by **June 20, 2026 (AEST)**.
+
+The current stack depends on older GPU/container build assumptions that are getting harder and more expensive to keep alive.
+We are investigating a lower-cost preservation path focused on keeping historic checkfaces available in some form, likely with more of the load shifted onto Hugging Face.
+
+If you have a workflow you want preserved, please email the address in the footer so we can factor it into the transition.
+
+---
+
 #### Are these real people?
 Images based on text input or numeric seeds are not really people. They are randomly generated.
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -19,6 +19,10 @@ html {
     overflow-x: auto;
 }
 
+body {
+    padding-bottom: 9rem;
+}
+
 .column {
     text-align: center;
 }
@@ -115,6 +119,73 @@ html {
     div:last-child {
         flex-grow: 1;
         text-align: center;
+    }
+}
+
+.retirement-notice {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1200;
+    padding: 0 1rem 1rem;
+    pointer-events: none;
+}
+
+.retirement-notice__content {
+    pointer-events: auto;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem 1.5rem;
+    align-items: center;
+    background: rgba(22, 25, 31, 0.94);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.28);
+    border-radius: 1rem;
+    padding: 1rem 1.25rem;
+
+    a {
+        color: #fff;
+        text-decoration: underline;
+        text-underline-offset: 0.18em;
+    }
+}
+
+.retirement-notice__copy {
+    flex: 1 1 28rem;
+    text-align: left;
+
+    p {
+        margin: 0;
+    }
+
+    p + p {
+        margin-top: 0.4rem;
+        color: rgba(255, 255, 255, 0.88);
+    }
+}
+
+.retirement-notice__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    align-items: center;
+}
+
+@media (max-width: 700px) {
+    body {
+        padding-bottom: 12rem;
+    }
+
+    .retirement-notice__content {
+        padding: 0.9rem 1rem;
+    }
+
+    .retirement-notice__actions {
+        width: 100%;
+        justify-content: flex-start;
     }
 }
 

--- a/vercel.package.json
+++ b/vercel.package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "engines": {
+    "node": "20.x"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,6 +93,7 @@ let client =
             new CopyWebpackPlugin({ patterns: [
                 { from: resolve(CONFIG.assetsDir) },
                 { from: resolve("vercel.json") },
+                { from: resolve("vercel.package.json"), to: "package.json" },
             ]}),
             new CleanWebpackPlugin({
                 cleanOnceBeforeBuildPatterns: ['**/*', '!api/**'],


### PR DESCRIPTION
## Summary
- add a fixed bottom retirement notice targeting June 20, 2026 (AEST)
- add feedback links for email and workflow requests
- add a matching FAQ entry explaining the planned service retirement and transition work

## Verification
- ran `npm run build`
- build completed successfully

## Notes
- this is intentionally a first user-facing warning, not the full transition page
- the broader Hugging Face migration architecture is being scoped separately