### PR TITLE
Move retirement copy to its own page

### DIFF
--- a/src/App.fs
+++ b/src/App.fs
@@ -356,11 +356,6 @@ let retirementNotice =
                                         prop.href "/retirement"
                                         prop.text "Learn more"
                                     ]
-                                    Mui.link [
-                                        link.color.initial
-                                        prop.href (sprintf "mailto:%s" contactEmail)
-                                        prop.text "Email us"
-                                    ]
                                 ]
                             ]
                         ]

--- a/src/App.fs
+++ b/src/App.fs
@@ -321,6 +321,45 @@ let footer =
         ]
     ]
 
+let retirementNotice =
+    Html.aside [
+        prop.className "retirement-notice"
+        prop.children [
+            Mui.container [
+                container.maxWidth.md
+                container.children [
+                    Html.div [
+                        prop.className "retirement-notice__content"
+                        prop.children [
+                            Html.div [
+                                prop.className "retirement-notice__copy"
+                                prop.children [
+                                    Html.p [
+                                        Html.strong "Planning notice."
+                                        str $" We expect facemorph.me to retire by %s{retirementDeadlineLabel}."
+                                    ]
+                                    Html.p [
+                                        str "We moved the detailed transition plan to its own page, but the homepage should still make the retirement status obvious."
+                                    ]
+                                ]
+                            ]
+                            Html.div [
+                                prop.className "retirement-notice__actions"
+                                prop.children [
+                                    Mui.link [
+                                        link.color.initial
+                                        prop.href "/retirement"
+                                        prop.text "Read retirement notice"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+
 let createTheme isDark = [
     if isDark then theme.palette.type'.dark else theme.palette.type'.light
     theme.palette.background.default' <| if isDark then "#17181c" else "white"
@@ -354,13 +393,19 @@ let ThemedApp children =
 let renderHome (state:State) (dispatch: Msg -> unit) =
     ThemedApp [
         Mui.cssBaseline [ ]
-        header
-        MorphForm.renderContent state dispatch
-        MorphForm.renderEncodeImageDialog state dispatch
-        MorphForm.renderBrowseFacesDialog state dispatch
-        viewShareContent (getShareState state) (ShareMsg >> dispatch)
-        Explain.view ()
-        footer
+        Html.div [
+            prop.className "page-with-retirement-notice"
+            prop.children [
+                header
+                MorphForm.renderContent state dispatch
+                MorphForm.renderEncodeImageDialog state dispatch
+                MorphForm.renderBrowseFacesDialog state dispatch
+                viewShareContent (getShareState state) (ShareMsg >> dispatch)
+                Explain.view ()
+                footer
+            ]
+        ]
+        retirementNotice
     ]
 
 let renderRetirement () =

--- a/src/App.fs
+++ b/src/App.fs
@@ -18,8 +18,13 @@ open Share
 open Config
 
 
+let parsePage = function
+    | "retirement"::_ -> Retirement
+    | _ -> Home
+
 let parseUrl (path, query) =
     {
+        Page = parsePage path
         FromValue = Map.tryFind "from_value" query
         ToValue = Map.tryFind "to_value" query
         FromGuid = Map.tryFind "from_guid" query |> Option.bind (System.Guid.TryParse >> tryToOption)
@@ -52,24 +57,36 @@ let formatPathForVidValues vidValues =
                 ()
         ])
 
-let canonicalUrl state =
-    canonicalBaseUrl + formatPathForVidValues state.VidValues
-
 let oEmbedUrl (url:string) =
     oEmbedApiEndpoint + (Feliz.Router.Router.formatPath("", [ "url", url ]))
 
-let pageTitle vidValues =
+let homePageTitle vidValues =
     match vidValues with
     | Some (fromValue, toValue) ->
         sprintf "%s to %s" (shortCheckfaceSrcDesc fromValue) (shortCheckfaceSrcDesc toValue)
     | None ->
         siteName + " face morpher"
 
-let pageDescription = function
+let homePageDescription = function
     | Some (fromValue, toValue) ->
             sprintf "Morph generated faces from %s to %s" (shortCheckfaceSrcDesc fromValue) (shortCheckfaceSrcDesc toValue)
     | None ->
             "Generate faces on the fly and morph between them"
+
+let canonicalUrl (state:State) =
+    match state.Page with
+    | Home -> canonicalBaseUrl + formatPathForVidValues state.VidValues
+    | Retirement -> canonicalBaseUrl + "/retirement"
+
+let pageTitle (state:State) =
+    match state.Page with
+    | Home -> homePageTitle state.VidValues
+    | Retirement -> $"Retirement notice | %s{siteName}"
+
+let pageDescription (state:State) =
+    match state.Page with
+    | Home -> homePageDescription state.VidValues
+    | Retirement -> "The facemorph.me retirement plan, including Hugging Face-backed hosting and the offline path."
 
 let getCurrentPath _ =
     Browser.Dom.window.location.pathname, Browser.Dom.window.location.search
@@ -103,6 +120,7 @@ let initByUrlstate urlState =
     let toValue = urlToCheckfaceSrc urlState
     let vidValues = Option.map2 (fun a b -> a,b) fromValue toValue
     {
+        Page = urlState.Page
         LeftValue = defaultFromValue fromValue
         RightValue = defaultToValue toValue
         UploadDialogSide = None
@@ -142,16 +160,16 @@ let updateShare msg state =
         match navigatorCanShare, state.VidValues with
         | true, None ->
             Cmd.OfPromise.result (promise {
-                ignore <| navigatorShare (canonicalUrl state) (pageTitle state.VidValues) (pageDescription state.VidValues)
+                ignore <| navigatorShare (canonicalUrl state) (pageTitle state) (pageDescription state)
                 return ShareMsg (SetShareMsg "Sharing page!")
             })
         | true, Some vidValues ->
             Cmd.OfPromise.result (promise {
                 let fileShare = {
-                    FileName = pageTitle state.VidValues + ".mp4"
-                    Title = pageTitle state.VidValues
+                    FileName = homePageTitle state.VidValues + ".mp4"
+                    Title = homePageTitle state.VidValues
                     FileUrl = vidSrc videoDim vidValues
-                    Text = (pageDescription state.VidValues)
+                    Text = (homePageDescription state.VidValues)
                     Url = (canonicalUrl state)
                     ContentType = "video/mp4"
                 }
@@ -203,6 +221,7 @@ let update msg state : State * Cmd<Msg> =
         let isLoading = vidValues <> state.VidValues && vidValues.IsSome
         {
             state with
+                Page = urlState.Page
                 LeftValue = defaultFromValue urlFromSrc
                 RightValue = defaultToValue urlToSrc
                 VidValues = vidValues
@@ -219,7 +238,7 @@ let update msg state : State * Cmd<Msg> =
         gtagEvent eventName "MorphSlider"
         { state with UseSlider = v }, Cmd.none
 
-let getShareState state =
+let getShareState (state:State) =
     {
         IsOpen = state.ShareOpen
         LinkMsg = state.ShareLinkMsg
@@ -302,45 +321,6 @@ let footer =
         ]
     ]
 
-let retirementNotice =
-    Html.aside [
-        prop.className "retirement-notice"
-        prop.children [
-            Mui.container [
-                container.maxWidth.md
-                container.children [
-                    Html.div [
-                        prop.className "retirement-notice__content"
-                        prop.children [
-                            Html.div [
-                                prop.className "retirement-notice__copy"
-                                prop.children [
-                                    Html.p [
-                                        Html.strong "Planning notice."
-                                        str $" We expect facemorph.me to retire by %s{retirementDeadlineLabel}."
-                                    ]
-                                    Html.p [
-                                        str "We are documenting the preservation path first so historic checkfaces can keep working in some form after the current Triton-backed service is retired."
-                                    ]
-                                ]
-                            ]
-                            Html.div [
-                                prop.className "retirement-notice__actions"
-                                prop.children [
-                                    Mui.link [
-                                        link.color.initial
-                                        prop.href "#learn-more-transition"
-                                        prop.text "Learn More"
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ]
-    ]
-
 let createTheme isDark = [
     if isDark then theme.palette.type'.dark else theme.palette.type'.light
     theme.palette.background.default' <| if isDark then "#17181c" else "white"
@@ -371,7 +351,7 @@ let ThemedApp children =
         themeProvider.children children
     ]
 
-let render (state:State) (dispatch: Msg -> unit) =
+let renderHome (state:State) (dispatch: Msg -> unit) =
     ThemedApp [
         Mui.cssBaseline [ ]
         header
@@ -381,8 +361,20 @@ let render (state:State) (dispatch: Msg -> unit) =
         viewShareContent (getShareState state) (ShareMsg >> dispatch)
         Explain.view ()
         footer
-        retirementNotice
     ]
+
+let renderRetirement () =
+    ThemedApp [
+        Mui.cssBaseline [ ]
+        header
+        Retirement.view ()
+        footer
+    ]
+
+let render (state:State) (dispatch: Msg -> unit) =
+    match state.Page with
+    | Home -> renderHome state dispatch
+    | Retirement -> renderRetirement ()
 
 let inline helmet props = createElement (Fable.Core.JsInterop.import "Helmet" "react-helmet") props
 
@@ -392,9 +384,10 @@ let meta (property:string) content =
         prop.custom ("content", content)
     ]
 
-let viewHead state =
+let viewHead (state:State) =
     let canonicalUrl = canonicalUrl state
-    let title = pageTitle state.VidValues
+    let title = pageTitle state
+    let description = pageDescription state
 
     helmet [
         prop.children [
@@ -402,52 +395,62 @@ let viewHead state =
             Html.meta [
                 prop.custom ("property", "description")
                 prop.custom ("name", "description")
-                prop.custom ("content", pageDescription None)
+                prop.custom ("content", description)
             ]
-            meta "og:title" (title)
-            meta "og:description" (pageDescription None)
+            meta "og:title" title
+            meta "og:description" description
             meta "og:site_name" siteName
 
             Html.link [ prop.rel.canonical; prop.href canonicalUrl ]
             meta "og:url" canonicalUrl
 
-            Html.link [
-                rel.alternate
-                prop.custom ("type", "application/json+oembed")
-                prop.href (oEmbedUrl canonicalUrl)
-                prop.title $"oEmbed for %s{title}"
-            ]
+            match state.Page with
+            | Home ->
+                Html.link [
+                    rel.alternate
+                    prop.custom ("type", "application/json+oembed")
+                    prop.href (oEmbedUrl canonicalUrl)
+                    prop.title $"oEmbed for %s{title}"
+                ]
 
-            match state.VidValues with
-            | None -> // just use left value if no video
+                match state.VidValues with
+                | None -> // just use left value if no video
+                    meta "og:image" (imgSrc ogImgDim false state.LeftValue)
+                    meta "og:image:alt" (imgAlt state.LeftValue)
+                    meta "og:image:width" ogImgDim
+                    meta "og:image:height" ogImgDim
+                    meta "og:image:type" "image/jpeg"
+                    meta "og:type" "website"
+
+                | Some vidValues ->
+                    let videoSrc = vidSrc ogVideoDim vidValues
+                    let linkprevSrc = linkpreviewSrc linkpreviewWidth vidValues
+                    let linkprevAlt = linkpreviewAlt vidValues
+
+                    meta "og:image" linkprevSrc
+                    meta "og:image:alt" linkprevAlt
+                    meta "og:image:width" linkpreviewWidth
+                    meta "og:image:height" linkpreviewHeight
+                    meta "og:image:type" "image/jpeg"
+
+                    meta "og:type" "video.other"
+                    meta "og:video" videoSrc
+                    meta "og:video:secure_url" videoSrc
+                    meta "og:video:type" "video/mp4"
+                    meta "og:video:width" ogVideoDim
+                    meta "og:video:height" ogVideoDim
+                    meta "twitter:card" "player"
+                    meta "twitter:player" (videoSrc + "&embed_html=true")
+                    meta "twitter:player:width" ogVideoDim
+                    meta "twitter:player:height" ogVideoDim
+
+            | Retirement ->
                 meta "og:image" (imgSrc ogImgDim false state.LeftValue)
                 meta "og:image:alt" (imgAlt state.LeftValue)
                 meta "og:image:width" ogImgDim
                 meta "og:image:height" ogImgDim
                 meta "og:image:type" "image/jpeg"
                 meta "og:type" "website"
-
-            | Some vidValues ->
-                let videoSrc = vidSrc ogVideoDim vidValues
-                let linkprevSrc = linkpreviewSrc linkpreviewWidth vidValues
-                let linkprevAlt = linkpreviewAlt vidValues
-
-                meta "og:image" linkprevSrc
-                meta "og:image:alt" linkprevAlt
-                meta "og:image:width" linkpreviewWidth
-                meta "og:image:height" linkpreviewHeight
-                meta "og:image:type" "image/jpeg"
-
-                meta "og:type" "video.other"
-                meta "og:video" videoSrc
-                meta "og:video:secure_url" videoSrc
-                meta "og:video:type" "video/mp4"
-                meta "og:video:width" ogVideoDim
-                meta "og:video:height" ogVideoDim
-                meta "twitter:card" "player"
-                meta "twitter:player" (videoSrc + "&embed_html=true")
-                meta "twitter:player:width" ogVideoDim
-                meta "twitter:player:height" ogVideoDim
         ]
     ]
 

--- a/src/App.fs
+++ b/src/App.fs
@@ -81,12 +81,12 @@ let canonicalUrl (state:State) =
 let pageTitle (state:State) =
     match state.Page with
     | Home -> homePageTitle state.VidValues
-    | Retirement -> $"Retirement notice | %s{siteName}"
+    | Retirement -> $"API transition | %s{siteName}"
 
 let pageDescription (state:State) =
     match state.Page with
     | Home -> homePageDescription state.VidValues
-    | Retirement -> "The facemorph.me retirement plan, including Hugging Face-backed hosting and the offline path."
+    | Retirement -> "Plans for retiring the current facemorph.me API and moving the site off the current Triton-hosted backend."
 
 let getCurrentPath _ =
     Browser.Dom.window.location.pathname, Browser.Dom.window.location.search
@@ -335,11 +335,16 @@ let retirementNotice =
                                 prop.className "retirement-notice__copy"
                                 prop.children [
                                     Html.p [
-                                        Html.strong "Planning notice."
-                                        str $" We expect facemorph.me to retire by %s{retirementDeadlineLabel}."
+                                        Html.strong "Notice."
+                                        str " The current facemorph.me API is scheduled to retire on "
+                                        Html.span [
+                                            prop.className "retirement-notice__date"
+                                            prop.text apiTransitionDateLabel
+                                        ]
+                                        str "."
                                     ]
                                     Html.p [
-                                        str "We moved the detailed transition plan to its own page, but the homepage should still make the retirement status obvious."
+                                        str "facemorph.me is staying up. We are planning a backend move, and Hugging Face is the leading candidate while we keep testing options."
                                     ]
                                 ]
                             ]
@@ -349,7 +354,12 @@ let retirementNotice =
                                     Mui.link [
                                         link.color.initial
                                         prop.href "/retirement"
-                                        prop.text "Read retirement notice"
+                                        prop.text "Learn more"
+                                    ]
+                                    Mui.link [
+                                        link.color.initial
+                                        prop.href (sprintf "mailto:%s" contactEmail)
+                                        prop.text "Email us"
                                     ]
                                 ]
                             ]

--- a/src/App.fsproj
+++ b/src/App.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="FancyButton.fs" />
     <Compile Include="SliderMorph.fs" />
     <Compile Include="Explain.fs" />
+    <Compile Include="Retirement.fs" />
     <Compile Include="BrowseFacesDialog.fs" />
     <Compile Include="EncodeImageDialog.fs" />
     <Compile Include="Share.fs" />

--- a/src/AppState.fs
+++ b/src/AppState.fs
@@ -4,7 +4,12 @@ open Checkface
 open Share
 
 type Side = | Left | Right
+type Page =
+    | Home
+    | Retirement
+
 type State = {
+    Page : Page
     VidValues : (CheckfaceSrc * CheckfaceSrc) option
     LeftValue : CheckfaceSrc
     RightValue : CheckfaceSrc
@@ -17,6 +22,7 @@ type State = {
 }
 
 type UrlState = {
+    Page : Page
     FromValue : string option
     ToValue : string option
     FromGuid : System.Guid Option

--- a/src/Config.fs
+++ b/src/Config.fs
@@ -15,7 +15,6 @@ let canonicalBaseUrl = "https://facemorph.me"
 let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
 let contactEmail = "checkfaceml@gmail.com"
 let githubRepo = "check-face/facemorph.me"
-let retirementDeadlineLabel = "June 20, 2026 (AEST)"
 
 let defaultTextValue = "hello"
 let defaultNumericSeed = 389u // 389 is one of the seeds featured in the stylegan2 paper

--- a/src/Config.fs
+++ b/src/Config.fs
@@ -15,7 +15,7 @@ let canonicalBaseUrl = "https://facemorph.me"
 let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
 let contactEmail = "checkfaceml@gmail.com"
 let githubRepo = "check-face/facemorph.me"
-let retirementDeadlineLabel = "June 20, 2026 (AEST)"
+let apiTransitionDateLabel = "June 20, 2026 (AEST)"
 
 let defaultTextValue = "hello"
 let defaultNumericSeed = 389u // 389 is one of the seeds featured in the stylegan2 paper

--- a/src/Config.fs
+++ b/src/Config.fs
@@ -15,6 +15,7 @@ let canonicalBaseUrl = "https://facemorph.me"
 let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
 let contactEmail = "checkfaceml@gmail.com"
 let githubRepo = "check-face/facemorph.me"
+let retirementDeadlineLabel = "June 20, 2026 (AEST)"
 
 let defaultTextValue = "hello"
 let defaultNumericSeed = 389u // 389 is one of the seeds featured in the stylegan2 paper

--- a/src/Retirement.fs
+++ b/src/Retirement.fs
@@ -1,0 +1,92 @@
+module Retirement
+
+open Feliz.MaterialUI
+open Feliz
+open Fulma
+open Fable.MaterialUI.Icons
+open Fable.Core.JsInterop
+
+let retirementContent : string = Fable.Core.JsInterop.importDefault "./retirement.md"
+
+let private useStyles = Styles.makeStyles (fun styles theme ->
+    {|
+        accordionSummary = styles.create [
+            style.backgroundColor theme.palette.background?level2
+        ]
+
+        content = styles.create [
+            style.maxWidth (length.percent 100)
+        ]
+    |})
+
+
+[<ReactComponent>]
+let Retirement () =
+    let c = useStyles ()
+
+    let parts =
+        retirementContent
+        |> List.unfold (fun (content:string) ->
+            match content, content.IndexOf "<hr>" with
+            | "", _ -> None
+            | _, -1 -> Some (content, "")
+            | _, idx -> Some (content.Substring(0, idx), content.Substring(idx + "<hr>".Length)))
+
+    let topContent = parts |> List.tryHead |> Option.defaultValue ""
+    let faqSections = match parts with | [ ] -> [ ] | _::tail -> tail
+    let faq = [
+        for part in faqSections do
+            let part = part.Trim([| ' '; '\n' |])
+            match part, part.LastIndexOf "</h" with
+            | _, -1 -> part, None
+            | _, 0 -> part, None
+            | _, idx -> part.Substring(0, idx + 5), Some (part.Substring(idx + 5))
+    ]
+
+    Mui.container [
+        container.maxWidth.md
+        prop.style [
+            style.marginBottom (length.em 2)
+        ]
+        container.children [
+            Content.content [ Content.Size IsLarge ] [
+                Html.div [
+                    prop.dangerouslySetInnerHTML topContent
+                ]
+            ]
+
+            Html.div [
+                for question, answer in faq do
+                    Mui.accordion [
+                        accordion.square true
+                        accordion.children [
+                            Mui.accordionSummary [
+                                accordionSummary.expandIcon (expandMoreIcon [ ])
+                                accordionSummary.classes.root c.accordionSummary
+                                prop.children [
+                                    Mui.typography [
+                                        typography.component' "h3"
+                                        typography.variant.h6
+                                        prop.dangerouslySetInnerHTML question
+                                    ]
+                                ]
+                            ]
+                            match answer with
+                            | None -> ()
+                            | Some answer ->
+                                Mui.accordionDetails [
+                                    Content.content [
+                                        Content.CustomClass c.content
+                                    ] [
+                                        Html.div [
+                                            prop.dangerouslySetInnerHTML answer
+                                        ]
+                                    ]
+                                ]
+                        ]
+                    ]
+            ]
+        ]
+    ]
+
+let view () = Retirement ()

--- a/src/explain.md
+++ b/src/explain.md
@@ -94,5 +94,6 @@ The source code for our server is at [github.com/check-face/checkface](https://g
 It is documented at [checkface.facemorph.me/api](https://checkface.facemorph.me/api)
 <!-- or at https://github.com/check-face/checkface/blob/master/docs/api.md -->
 
-We recommented hosting the server yourself as we do not plan on running it reliably or indefinitely.
-Feel free to contact us using the email address in the footer.
+If you need a setup you can keep under your own control, self-hosting `checkface` is still the safest option for now.
+
+If you hit a bug in `checkface`, please open a GitHub issue. If you have questions about the API transition, or a workflow you want us to keep in mind, email us at [checkfaceml@gmail.com](mailto:checkfaceml@gmail.com) and we will do our best to help.

--- a/src/explain.md
+++ b/src/explain.md
@@ -23,105 +23,9 @@ It attempts to find a balance between accuracy and editability.
 This tradeoff means it won't look quite the same as the input
 image but should work well for morphing.
 
-<div id="learn-more-transition"></div>
-
-## Retirement and transition
-
-facemorph.me is now in retirement planning mode and the current goal is to retire the existing always-on service by **June 20, 2026 (AEST)**.
-
-The point of this page is to explain the process before anything major changes.
-The current site is still online while we document the service, audit historic hashes and cached outputs, and test lower-cost ways to keep the important parts alive after the current Triton-backed deployment is retired.
-
-### Why this is happening
-
-The present deployment depends on an aging GPU and container stack that is getting harder and more expensive to keep online.
-That stack has been useful for a long time, but it is no longer a good forever-home for a public always-on service.
-
-We want to avoid a bad outcome where the old stack simply becomes too expensive or brittle and then disappears without warning.
-The goal here is to document the service properly, preserve what matters most, and move users onto a lower-cost path in a more deliberate way.
-
-### What we are trying to preserve
-
-- historic checkfaces that users already rely on
-- the ability to match historic hashes where we can verify exact preservation
-- a usable replacement path for people who still want to generate faces after the current machine is retired
-- enough documentation that people can understand what changed and, if necessary, run their own copy locally in future
-
-### What is happening now
-
-Right now we are still in the planning and documentation stage.
-That means:
-
-- the current site stays up while we investigate
-- we are inventorying old cached outputs and historic hash behavior
-- we are working out which results can be preserved exactly and which may need a slower replacement path
-- we expect to use `testing.facemorph.me` as the place for candidate replacements before changing the main site
-- we are looking at Hugging Face as the most likely low-cost home for at least part of the future service
-
-### What may change later
-
-We expect the post-transition service to be more explicit about tradeoffs than the current setup.
-Depending on what we prove during the investigation, that may mean:
-
-- slower on-demand generation instead of a permanently warm GPU service
-- sign-in via Hugging Face for some compute-heavy workflows
-- archived historic outputs being served directly, rather than regenerated every time
-- a replacement API surface that is similar to today's API, or a documented move onto Hugging Face-native equivalents
-- some older or more expensive flows being documented for self-hosting rather than kept online as a public free service
-
-### The planned process
-
-1. Document the current Triton deployment, data layout, and existing public behavior.
-2. Audit the historic hashes, cached outputs, and model/version boundaries so we know what "preservation" really means.
-3. Prototype lower-cost replacements, most likely using Hugging Face for authentication and at least some generation or archive-serving duties.
-4. Publish test builds and placeholder flows on `testing.facemorph.me` so users can try them before production changes.
-5. Publish final retirement details only after we understand what can be preserved exactly, what will be slower, and what will need to change.
-6. Retire the old always-on service once the replacement path and archive story are documented well enough to stand on their own.
-
-### What is not promised yet
-
-We do **not** want to overstate what is solved.
-At this stage we are still validating the details, so we are **not** yet promising:
-
-- exact parity for every uncached request
-- the same performance profile as the current server
-- indefinite uptime for the current API
-- that every current workflow will survive unchanged
-
-### API users
-
-The current API will eventually need to be retired along with the current machine.
-Before that happens, we intend to document the likely replacement path clearly.
-
-The most likely direction is that the API stops being a public always-on service on our own GPU box and becomes one of:
-
-- a Hugging Face-backed replacement
-- a thinner compatibility layer in front of a Hugging Face workflow
-- a more limited preservation endpoint for historic content, with newer generation handled separately
-
-That work is still being scoped.
-If you depend on the API, the main thing to expect right now is more documentation, a testing surface, and advance notice before the old endpoint is shut down.
-
-### Before you contact us
-
-Please read this page first.
-If you still have a workflow that you need preserved after reading it, email the address in the footer and explain the exact path you rely on.
-
-For transition questions and preservation feedback, please use email rather than GitHub issues.
-
 ## FAQ
 
-#### Is facemorph.me being retired?
-Yes.
-The current goal is to retire the existing always-on service by **June 20, 2026 (AEST)**, but this page exists specifically so the process is documented before that happens.
-
-#### Is anything changing today?
-Not yet in a major way.
-The current site is still online while we document the existing service, investigate historic hash preservation, and prepare a testing surface for whatever comes next.
-
-#### What should API users expect?
-The current Triton-hosted API is not intended to remain the long-term public service.
-Before that changes, we intend to document the replacement direction clearly, publish a testing surface, and give advance notice rather than simply switching it off.
+---
 
 #### Are these real people?
 Images based on text input or numeric seeds are not really people. They are randomly generated.
@@ -190,5 +94,5 @@ The source code for our server is at [github.com/check-face/checkface](https://g
 It is documented at [checkface.facemorph.me/api](https://checkface.facemorph.me/api)
 <!-- or at https://github.com/check-face/checkface/blob/master/docs/api.md -->
 
-We recommended hosting the server yourself as we do not plan on running it reliably or indefinitely.
+We recommented hosting the server yourself as we do not plan on running it reliably or indefinitely.
 Feel free to contact us using the email address in the footer.

--- a/src/retirement.md
+++ b/src/retirement.md
@@ -14,7 +14,7 @@ This is the direction we are working toward:
 - preserve the workflows people actually use where we can
 - document what changes, what stays, and what local options still make sense
 
-Nothing changes overnight. We are in the transition period now, so if you think this plan is going to make something harder for you, we would like to hear about it.
+Nothing changes overnight. We are in the transition period now, and we expect to test the next setup at **testing.facemorph.me** before any broader migration. If you think this plan is going to make something harder for you, we would like to hear about it.
 
 If you think this could break something you rely on, or if there is a workflow that needs special care, email **checkfaceml@gmail.com**. We cannot promise support for every case, but we will read the feedback and try to help where we can.
 

--- a/src/retirement.md
+++ b/src/retirement.md
@@ -1,0 +1,62 @@
+## A note about facemorph.me
+
+We do plan to retire facemorph.me. The current target is **June 20, 2026 (AEST)**.
+
+The main reason is simple: the site still runs on our local server in the garage. That has been fun, but it is getting harder and more expensive to keep a public service running that way.
+
+The replacement plan is not just "maybe something cheaper later." We want to keep the Facemorph UI public, move the hosted compute onto Hugging Face, and have users sign in with Hugging Face when they want the hosted service to do work for them.
+
+We also want to document the offline path properly. If you want to produce your own hashes, upload photos locally, or run the workflow on your own machine, there should be clear instructions for that too.
+
+Nothing big is changing today. The site is still online while we work through the boring but important parts: old hashes, cached results, and the workflows people actually use.
+
+We are not planning to chase every new technique just because it is newer. The goal is to keep the existing workflow available in a cleaner and cheaper way.
+
+ComfyUI is still worth mentioning. It is active, flexible, and it can cover a lot of the same ground with newer models. It also comes with caveats, and it is not the main hosted migration plan for facemorph.me.
+
+## FAQ
+
+---
+
+#### Is facemorph.me being retired?
+Yes. That is the plan, and the current target is **June 20, 2026 (AEST)**.
+
+---
+
+#### What is the hosted plan?
+Keep the Facemorph UI public, but move the hosted compute onto Hugging Face. If you want the hosted service to generate or process something for you, the plan is that you would sign in with Hugging Face first.
+
+---
+
+#### Will there still be a local or offline path?
+That is the plan too. We want to publish clearer instructions for people who want to generate their own hashes, upload photos locally, or run the workflow on their own machine without relying on the hosted service.
+
+---
+
+#### Are you planning to rebuild everything around newer models?
+No. We are not planning a big rewrite just for the sake of using newer techniques. The main goal is to preserve the existing workflow in a form that is easier to keep online.
+
+---
+
+#### Where does ComfyUI fit in?
+ComfyUI is an actively maintained tool and it can support a lot of workflows that overlap with facemorph.me, sometimes with better models. It is still a separate tool with tradeoffs, so we see it as something worth documenting, not as a drop-in replacement for the current hosted service.
+
+---
+
+#### Is anything changing today?
+Not in a big way. The site is still up while we sort through what can be kept, what may get slower, and what needs a different home.
+
+---
+
+#### I depend on a specific workflow. What should I do?
+Email us and describe the exact workflow you need. "I use the API" is harder to act on than "I call this endpoint with these inputs and need this output."
+
+---
+
+#### Why not just keep the current server online?
+Because the site still depends on our local server in the garage. That machine will not be the forever home for a public service, and we would rather say that clearly now than pretend otherwise.
+
+---
+
+#### Should I use GitHub issues for retirement questions?
+Please use email instead. GitHub issues are still useful for bugs in the current site. Transition questions and workflow requests are easier for us to handle over email.

--- a/src/retirement.md
+++ b/src/retirement.md
@@ -14,7 +14,7 @@ This is the direction we are working toward:
 - preserve the workflows people actually use where we can
 - document what changes, what stays, and what local options still make sense
 
-Nothing changes overnight. We are in the transition period now, and we expect to test the next setup at **testing.facemorph.me** before any broader migration. If you think this plan is going to make something harder for you, we would like to hear about it.
+Nothing changes overnight. We are in the transition period now, and we expect to test the next setup at **testing.facemorph.me** before any broader migration. We know some workflows will get harder. If you think this breaks a use case people care about, we would like to hear about it.
 
 If you think this could break something you rely on, or if there is a workflow that needs special care, email **checkfaceml@gmail.com**. We cannot promise support for every case, but we will read the feedback and try to help where we can.
 

--- a/src/retirement.md
+++ b/src/retirement.md
@@ -1,62 +1,68 @@
-## A note about facemorph.me
+## A note about the facemorph.me API
 
-We do plan to retire facemorph.me. The current target is **June 20, 2026 (AEST)**.
+The current facemorph.me API is scheduled to retire on **June 20, 2026 (AEST)**.
 
-The main reason is simple: the site still runs on our local server in the garage. That has been fun, but it is getting harder and more expensive to keep a public service running that way.
+facemorph.me itself is not going away. What is changing is the current Triton-hosted API and the checkface backend we currently run ourselves.
 
-The replacement plan is not just "maybe something cheaper later." We want to keep the Facemorph UI public, move the hosted compute onto Hugging Face, and have users sign in with Hugging Face when they want the hosted service to do work for them.
+The goal is to move the site onto a provider that is easier for us to keep online over time, while keeping the main experience available. We are still exploring the exact path. Right now, **Hugging Face is the leading candidate**, but we are still testing options and we are not calling the details final yet.
 
-We also want to document the offline path properly. If you want to produce your own hashes, upload photos locally, or run the workflow on your own machine, there should be clear instructions for that too.
+This is the direction we are working toward:
 
-Nothing big is changing today. The site is still online while we work through the boring but important parts: old hashes, cached results, and the workflows people actually use.
+- keep facemorph.me online
+- retire the current API in its current form
+- move the backend off our own compute
+- preserve the workflows people actually use where we can
+- document what changes, what stays, and what local options still make sense
 
-We are not planning to chase every new technique just because it is newer. The goal is to keep the existing workflow available in a cleaner and cheaper way.
+Nothing changes overnight. We are in the transition period now, so if you think this plan is going to make something harder for you, we would like to hear about it.
 
-ComfyUI is still worth mentioning. It is active, flexible, and it can cover a lot of the same ground with newer models. It also comes with caveats, and it is not the main hosted migration plan for facemorph.me.
+If you think this could break something you rely on, or if there is a workflow that needs special care, email **checkfaceml@gmail.com**. We cannot promise support for every case, but we will read the feedback and try to help where we can.
+
+For some local checkface or facemorph workflows, **ComfyUI** may also be useful. It is not the hosted migration plan, but it may be a practical local option for image modification on your own machine.
 
 ## FAQ
 
 ---
 
-#### Is facemorph.me being retired?
-Yes. That is the plan, and the current target is **June 20, 2026 (AEST)**.
+#### Is facemorph.me shutting down?
+No. facemorph.me is expected to stay up. The part scheduled to retire on **June 20, 2026 (AEST)** is the current API and backend we run on our own compute.
 
 ---
 
-#### What is the hosted plan?
-Keep the Facemorph UI public, but move the hosted compute onto Hugging Face. If you want the hosted service to generate or process something for you, the plan is that you would sign in with Hugging Face first.
+#### What is changing on June 20, 2026?
+That is the current target date for retiring the API in its current form. It is not a promise that the whole site disappears on that day.
+
+---
+
+#### What is the leading replacement plan?
+Hugging Face is the leading candidate right now. It looks like the most practical place to move the hosted compute, but we are still testing options before we make stronger promises about the final setup.
+
+---
+
+#### Are you still exploring other options?
+Yes. We have a direction, not a finished answer. We want to test replacement paths before we claim that one approach is final.
 
 ---
 
 #### Will there still be a local or offline path?
-That is the plan too. We want to publish clearer instructions for people who want to generate their own hashes, upload photos locally, or run the workflow on their own machine without relying on the hosted service.
+We intend to document one. For some local image modification workflows, ComfyUI may be a useful fit, and we also want clearer notes for people who want to run parts of the workflow themselves.
 
 ---
 
-#### Are you planning to rebuild everything around newer models?
-No. We are not planning a big rewrite just for the sake of using newer techniques. The main goal is to preserve the existing workflow in a form that is easier to keep online.
+#### Will the API stay exactly the same?
+We are not promising that yet. Some parts may stay compatible, some may need a thinner replacement layer, and some may end up as a smaller surface. We would rather say that plainly now than surprise people later.
 
 ---
 
-#### Where does ComfyUI fit in?
-ComfyUI is an actively maintained tool and it can support a lot of workflows that overlap with facemorph.me, sometimes with better models. It is still a separate tool with tradeoffs, so we see it as something worth documenting, not as a drop-in replacement for the current hosted service.
-
----
-
-#### Is anything changing today?
-Not in a big way. The site is still up while we sort through what can be kept, what may get slower, and what needs a different home.
-
----
-
-#### I depend on a specific workflow. What should I do?
-Email us and describe the exact workflow you need. "I use the API" is harder to act on than "I call this endpoint with these inputs and need this output."
+#### I think this may break something I use. What should I do?
+Email us at **checkfaceml@gmail.com** and tell us what you are trying to do. If you can already see a problem with the plan, that is exactly the kind of feedback we want during the transition period. We cannot promise support for every workflow, but we will do our best to help.
 
 ---
 
 #### Why not just keep the current server online?
-Because the site still depends on our local server in the garage. That machine will not be the forever home for a public service, and we would rather say that clearly now than pretend otherwise.
+The current setup has served us well, but it was never meant to be the forever home for a public service. We would rather move it carefully, with warning, than keep stretching the current setup until it becomes a problem.
 
 ---
 
-#### Should I use GitHub issues for retirement questions?
-Please use email instead. GitHub issues are still useful for bugs in the current site. Transition questions and workflow requests are easier for us to handle over email.
+#### Where should I send transition questions or feedback?
+Email **checkfaceml@gmail.com**. GitHub issues are still useful for bugs in the **checkface** project that powers facemorph.me, but transition questions and workflow concerns are easier for us to handle over email.

--- a/src/style.scss
+++ b/src/style.scss
@@ -19,6 +19,10 @@ html {
     overflow-x: auto;
 }
 
+.page-with-retirement-notice {
+    padding-bottom: 9rem;
+}
+
 .column {
     text-align: center;
 }
@@ -115,6 +119,73 @@ html {
     div:last-child {
         flex-grow: 1;
         text-align: center;
+    }
+}
+
+.retirement-notice {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1200;
+    padding: 0 1rem 1rem;
+    pointer-events: none;
+}
+
+.retirement-notice__content {
+    pointer-events: auto;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem 1.5rem;
+    align-items: center;
+    background: rgba(22, 25, 31, 0.94);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.28);
+    border-radius: 1rem;
+    padding: 1rem 1.25rem;
+
+    a {
+        color: #fff;
+        text-decoration: underline;
+        text-underline-offset: 0.18em;
+    }
+}
+
+.retirement-notice__copy {
+    flex: 1 1 28rem;
+    text-align: left;
+
+    p {
+        margin: 0;
+    }
+
+    p + p {
+        margin-top: 0.4rem;
+        color: rgba(255, 255, 255, 0.88);
+    }
+}
+
+.retirement-notice__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+    align-items: center;
+}
+
+@media (max-width: 700px) {
+    .page-with-retirement-notice {
+        padding-bottom: 12rem;
+    }
+
+    .retirement-notice__content {
+        padding: 0.9rem 1rem;
+    }
+
+    .retirement-notice__actions {
+        width: 100%;
+        justify-content: flex-start;
     }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -19,10 +19,6 @@ html {
     overflow-x: auto;
 }
 
-body {
-    padding-bottom: 9rem;
-}
-
 .column {
     text-align: center;
 }
@@ -119,73 +115,6 @@ body {
     div:last-child {
         flex-grow: 1;
         text-align: center;
-    }
-}
-
-.retirement-notice {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 1200;
-    padding: 0 1rem 1rem;
-    pointer-events: none;
-}
-
-.retirement-notice__content {
-    pointer-events: auto;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 1rem 1.5rem;
-    align-items: center;
-    background: rgba(22, 25, 31, 0.94);
-    color: #fff;
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.28);
-    border-radius: 1rem;
-    padding: 1rem 1.25rem;
-
-    a {
-        color: #fff;
-        text-decoration: underline;
-        text-underline-offset: 0.18em;
-    }
-}
-
-.retirement-notice__copy {
-    flex: 1 1 28rem;
-    text-align: left;
-
-    p {
-        margin: 0;
-    }
-
-    p + p {
-        margin-top: 0.4rem;
-        color: rgba(255, 255, 255, 0.88);
-    }
-}
-
-.retirement-notice__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem 1rem;
-    align-items: center;
-}
-
-@media (max-width: 700px) {
-    body {
-        padding-bottom: 12rem;
-    }
-
-    .retirement-notice__content {
-        padding: 0.9rem 1rem;
-    }
-
-    .retirement-notice__actions {
-        width: 100%;
-        justify-content: flex-start;
     }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -20,7 +20,7 @@ html {
 }
 
 .page-with-retirement-notice {
-    padding-bottom: 9rem;
+    padding-bottom: 10rem;
 }
 
 .column {
@@ -138,7 +138,7 @@ html {
     flex-wrap: wrap;
     justify-content: space-between;
     gap: 1rem 1.5rem;
-    align-items: center;
+    align-items: flex-start;
     background: rgba(22, 25, 31, 0.94);
     color: #fff;
     border: 1px solid rgba(255, 255, 255, 0.14);
@@ -159,6 +159,8 @@ html {
 
     p {
         margin: 0;
+        font-size: 1rem;
+        line-height: 1.5;
     }
 
     p + p {
@@ -167,16 +169,27 @@ html {
     }
 }
 
+.retirement-notice__date {
+    font-size: 1.05rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
 .retirement-notice__actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem 1rem;
     align-items: center;
+
+    a {
+        font-size: 1rem;
+        line-height: 1.5;
+    }
 }
 
 @media (max-width: 700px) {
     .page-with-retirement-notice {
-        padding-bottom: 12rem;
+        padding-bottom: 14.5rem;
     }
 
     .retirement-notice__content {


### PR DESCRIPTION
## Summary
- restore the homepage content to its pre-banner state
- move the retirement and migration explanation to a dedicated `/retirement` page
- rewrite the retirement copy so it states the actual Hugging Face / offline / ComfyUI plan without internal infra jargon

## Verification
- ran `npm run build`
- smoke tested `deploy/` with `npx vercel@latest dev deploy --listen 4310 --yes`
- confirmed `/` shows the original homepage FAQ flow and `/retirement` shows the new retirement page

## Notes
- this PR is intentionally left as draft so the preview can be checked before any merge
- no production deploy was triggered from this branch