### PR TITLE
Push API retirement to Oct 25, soften feedback FAQ

### DIFF
--- a/src/App.fs
+++ b/src/App.fs
@@ -335,8 +335,8 @@ let retirementNotice =
                                 prop.className "retirement-notice__copy"
                                 prop.children [
                                     Html.p [
-                                        Html.strong "Notice."
-                                        str " The current facemorph.me API is scheduled to retire on "
+                                        Html.strong "Update."
+                                        str " We have pushed the facemorph.me API retirement back to "
                                         Html.span [
                                             prop.className "retirement-notice__date"
                                             prop.text apiTransitionDateLabel
@@ -344,7 +344,7 @@ let retirementNotice =
                                         str "."
                                     ]
                                     Html.p [
-                                        str "facemorph.me is staying up. We are planning a backend move, and Hugging Face is the leading candidate while we keep testing options."
+                                        str "facemorph.me is staying up. We moved the date after a lot of you asked us to, so we can give the feedback the consideration it deserves. Hugging Face is still the leading candidate while we keep testing options."
                                     ]
                                 ]
                             ]

--- a/src/Config.fs
+++ b/src/Config.fs
@@ -15,7 +15,7 @@ let canonicalBaseUrl = "https://facemorph.me"
 let oEmbedApiEndpoint = canonicalBaseUrl + "/oembed.json"
 let contactEmail = "checkfaceml@gmail.com"
 let githubRepo = "check-face/facemorph.me"
-let apiTransitionDateLabel = "June 20, 2026 (AEST)"
+let apiTransitionDateLabel = "October 25, 2026 (AEST)"
 
 let defaultTextValue = "hello"
 let defaultNumericSeed = 389u // 389 is one of the seeds featured in the stylegan2 paper

--- a/src/retirement.md
+++ b/src/retirement.md
@@ -1,6 +1,8 @@
 ## A note about the facemorph.me API
 
-The current facemorph.me API is scheduled to retire on **June 20, 2026 (AEST)**.
+The current facemorph.me API is now scheduled to retire on **October 25, 2026 (AEST)**.
+
+We have pushed this back from the original June date. Part of that is popular demand — a lot of people asked us for more time — and part of it is that we want to properly sit with the feedback we have had rather than rush the change. We would rather move slowly and get it right.
 
 facemorph.me itself is not going away. What is changing is the current API and the way the checkface backend is hosted today.
 
@@ -25,12 +27,21 @@ For some local checkface or facemorph workflows, **ComfyUI** may also be useful.
 ---
 
 #### Is facemorph.me shutting down?
-No. facemorph.me is expected to stay up. The part scheduled to retire on **June 20, 2026 (AEST)** is the current API and backend in their current form.
+No. facemorph.me is expected to stay up. The part scheduled to retire on **October 25, 2026 (AEST)** is the current API and backend in their current form.
 
 ---
 
-#### What is changing on June 20, 2026?
-That is the current target date for retiring the API in its current form. It is not a promise that the whole site disappears on that day.
+#### What is changing on October 25, 2026?
+That is the current target date for retiring the API in its current form. We moved it back from June to give the feedback we received proper consideration. It is not a promise that the whole site disappears on that day.
+
+---
+
+#### "I'm not happy about features being removed from a service." How do you respond?
+That is completely fair, and we would feel the same way. Nobody likes losing something they have come to rely on, and we do not want to wave that away. It is a real part of why we pushed the date back.
+
+The honest context is that facemorph.me has always been free — no ads, no accounts, no charges — and the servers come out of our own pockets. We mention that not to dismiss the concern but to explain the constraint we are working within: the current setup is getting harder for us to keep running, and the choice in front of us was to move it or eventually lose it. We would much rather move it.
+
+So the goal is not to take things away. The whole reason we are moving to a new backend rather than switching it off is to keep as much of what people use working as we can. If there is a feature that matters to you, please tell us at **checkfaceml@gmail.com** — knowing what people rely on is exactly what helps us protect it.
 
 ---
 


### PR DESCRIPTION
## What

- Move the API transition date from **June 20** to **October 25, 2026 (AEST)** — pushed back by popular demand and to give the feedback we received proper consideration.
- Update the homepage banner (`App.fs`) and the retirement copy/FAQ (`retirement.md`) to reflect the new date.
- Rework the "I'm not happy about features being removed from a service" FAQ to engage in good faith: validate the concern, mention the free / self-funded hosting as *context for the constraint* (not a rebuttal), and reaffirm that the backend move exists to preserve features rather than remove them.

## Files

- `src/Config.fs` — `apiTransitionDateLabel` → October 25, 2026 (AEST)
- `src/App.fs` — banner reworded ("Update. We have pushed the retirement back to …")
- `src/retirement.md` — intro rationale, date references, reworked feedback FAQ

## Notes

CI (`deploy.yml`) builds a preview deploy for this PR; merging to `master` ships to production. `deploy/` is gitignored and rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)